### PR TITLE
Fixed nginx bail during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,8 @@ MAINTAINER Nathan Hopkins, natehop@gmail.com
 
 ADD assets /opt/hopsoft/graphite-statsd
 RUN /opt/hopsoft/graphite-statsd/install
+
+###
+# Ensure that nginx has it's log directory to write to or it'll shit a brick
+###
+RUN mkdir -p /var/log/nginx


### PR DESCRIPTION
Directory needs to be created in order to let the build continue as prescribed
