### PR TITLE
Allow third party dashboards to query graphite

### DIFF
--- a/assets/build
+++ b/assets/build
@@ -131,6 +131,10 @@ server {
         include fastcgi_params;
         fastcgi_split_path_info ^()(.*)$;
         fastcgi_pass 127.0.0.1:8080;
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST';
+        add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type';
+        add_header 'Access-Control-Allow-Credentials' 'true';
     }
 }
 EOF


### PR DESCRIPTION
I have added CORS rules to the Nginx configuration to allow Cross Origin requests from other dashboards, such as Grafana.
