### PR TITLE
remove sudo to avoid start error

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -3,7 +3,7 @@
 docker_tag=${1:-"hopsoft/graphite-statsd"}
 container_name=${2:-"graphite"}
 
-sudo docker run \
+docker run \
 	--name="$container_name" \
 	-d -i -t \
 	-p 80:80 \


### PR DESCRIPTION
It was getting me the "/var/run/docker.sock: no such file or directory"
once that I removed "sudo" it work with no problem
