### PR TITLE
Updated storage-schemas.conf

### DIFF
--- a/conf/graphite/storage-schemas.conf
+++ b/conf/graphite/storage-schemas.conf
@@ -8,6 +8,10 @@
 # Carbon's internal metrics. This entry should match what is specified in
 # CARBON_METRIC_PREFIX and CARBON_METRIC_INTERVAL settings
 
+[carbon]
+pattern = ^carbon\.
+retentions = 10s:6h,1min:90d
+
 [default_1min_for_1day]
 pattern = .*
 retentions = 10s:6h,1min:6d,10min:1800d

--- a/conf/graphite/storage-schemas.conf
+++ b/conf/graphite/storage-schemas.conf
@@ -7,10 +7,7 @@
 
 # Carbon's internal metrics. This entry should match what is specified in
 # CARBON_METRIC_PREFIX and CARBON_METRIC_INTERVAL settings
-[carbon]
-pattern = ^carbon\.
-retentions = 60:90d
 
 [default_1min_for_1day]
 pattern = .*
-retentions = 60s:1d
+retentions = 10s:6h,1min:6d,10min:1800d


### PR DESCRIPTION
The statsd flush is less than graphites storage scheme. This means that graphite is throwing some metrics away.