### PR TITLE
Send stats to carbon-aggregator from statsd

### DIFF
--- a/conf/statsd/config.js
+++ b/conf/statsd/config.js
@@ -1,6 +1,6 @@
 {
   "graphiteHost": "127.0.0.1",
-  "graphitePort": 2003,
+  "graphitePort": 2023,
   "port": 8125,
   "flushInterval": 10000
 }


### PR DESCRIPTION
You need to point your statsd to the carbon-aggregator.py port on 2023, NOT carbon-cache.py on 2003. If sending directly to 2003, the stats would miss the aggregator.
https://answers.launchpad.net/graphite/+question/199769
