### PR TITLE
Update graphite, whisper, carbon version to 0.9.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:0.9.15
+FROM phusion/baseimage:0.9.18
 MAINTAINER Nathan Hopkins <natehop@gmail.com>
 
 #RUN echo deb http://archive.ubuntu.com/ubuntu $(lsb_release -cs) main universe > /etc/apt/sources.list.d/universe.list
@@ -22,26 +22,26 @@ RUN apt-get -y --force-yes install vim\
  nodejs
 
 # python dependencies
-RUN pip install django==1.3\
+RUN pip install django==1.5.12\
  python-memcached==1.53\
  django-tagging==0.3.1\
  twisted==11.1.0\
  txAMQP==0.6.2
 
 # install graphite
-RUN git clone -b 0.9.12 --depth 1 https://github.com/graphite-project/graphite-web.git /usr/local/src/graphite-web
+RUN git clone -b 0.9.15 --depth 1 https://github.com/graphite-project/graphite-web.git /usr/local/src/graphite-web
 WORKDIR /usr/local/src/graphite-web
 RUN python ./setup.py install
 ADD scripts/local_settings.py /opt/graphite/webapp/graphite/local_settings.py
 ADD conf/graphite/ /opt/graphite/conf/
 
 # install whisper
-RUN git clone -b 0.9.12 --depth 1 https://github.com/graphite-project/whisper.git /usr/local/src/whisper
+RUN git clone -b 0.9.15 --depth 1 https://github.com/graphite-project/whisper.git /usr/local/src/whisper
 WORKDIR /usr/local/src/whisper
 RUN python ./setup.py install
 
 # install carbon
-RUN git clone -b 0.9.12 --depth 1 https://github.com/graphite-project/carbon.git /usr/local/src/carbon
+RUN git clone -b 0.9.15 --depth 1 https://github.com/graphite-project/carbon.git /usr/local/src/carbon
 WORKDIR /usr/local/src/carbon
 RUN python ./setup.py install
 

--- a/conf/graphite/storage-schemas.conf
+++ b/conf/graphite/storage-schemas.conf
@@ -10,8 +10,8 @@
 
 [carbon]
 pattern = ^carbon\.
-retentions = 10s:6h,1min:90d
+retentions = 1s:6h,1min:90d
 
 [default_1min_for_1day]
 pattern = .*
-retentions = 10s:6h,1min:6d,10min:1800d
+retentions = 1s:6h,1min:6d,10min:1800d

--- a/conf/statsd/config.js
+++ b/conf/statsd/config.js
@@ -2,5 +2,5 @@
   "graphiteHost": "127.0.0.1",
   "graphitePort": 2003,
   "port": 8125,
-  "flushInterval": 10000
+  "flushInterval": 1000
 }

--- a/scripts/django_admin_init.exp
+++ b/scripts/django_admin_init.exp
@@ -7,11 +7,11 @@ expect "Would you like to create one now" {
   send "yes\r"
 }
 
-expect "Username *:" {
+expect "Username:" {
   send "root\r"
 }
 
-expect "E-mail address:" {
+expect "Email address:" {
   send "root.graphite@mailinator.com\r"
 }
 


### PR DESCRIPTION
The update of Django to 1.4 is a requirement [see](https://github.com/graphite-project/graphite-web/issues/650) for graphite 0.9.x 

For testing it's available in dockerhub: [elpicador/graphite-statsd](https://hub.docker.com/r/elpicador/graphite-statsd/)