### PR TITLE
Fix storage-schema for carbon stats

### DIFF
--- a/conf/opt/graphite/conf/storage-schemas.conf
+++ b/conf/opt/graphite/conf/storage-schemas.conf
@@ -10,7 +10,7 @@
 
 [carbon]
 pattern = ^carbon\.
-retentions = 10s:6h,1min:90d
+retentions = 1min:90d
 
 [default_1min_for_1day]
 pattern = .*


### PR DESCRIPTION
Since carbon only commit data every 60s, the data
points will be lost during aggregation.

Change schema to match carbons commit rate.
