### PR TITLE
Fix runit run scripts

### DIFF
--- a/conf/etc/service/carbon-aggregator/run
+++ b/conf/etc/service/carbon-aggregator/run
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-/usr/bin/python /opt/graphite/bin/carbon-aggregator.py start --debug 2>&1 >> /var/log/carbon-aggregator.log
+exec /usr/bin/python /opt/graphite/bin/carbon-aggregator.py start --debug 2>&1 >> /var/log/carbon-aggregator.log

--- a/conf/etc/service/carbon/run
+++ b/conf/etc/service/carbon/run
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-/usr/bin/python /opt/graphite/bin/carbon-cache.py start --debug 2>&1 >> /var/log/carbon.log
+exec /usr/bin/python /opt/graphite/bin/carbon-cache.py start --debug 2>&1 >> /var/log/carbon.log

--- a/conf/etc/service/graphite/run
+++ b/conf/etc/service/graphite/run
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-/usr/bin/python /opt/graphite/webapp/graphite/manage.py runfcgi daemonize=false host=127.0.0.1 port=8080
+exec /usr/bin/python /opt/graphite/webapp/graphite/manage.py runfcgi daemonize=false host=127.0.0.1 port=8080
 

--- a/conf/etc/service/nginx/run
+++ b/conf/etc/service/nginx/run
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 mkdir -p /var/log/nginx
-/usr/sbin/nginx -c /etc/nginx/nginx.conf
+exec /usr/sbin/nginx -c /etc/nginx/nginx.conf

--- a/conf/etc/service/statsd/run
+++ b/conf/etc/service/statsd/run
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-/usr/bin/nodejs /opt/statsd/stats.js /opt/statsd/config.js >> /var/log/statsd.log 2>&1
+exec /usr/bin/nodejs /opt/statsd/stats.js /opt/statsd/config.js >> /var/log/statsd.log 2>&1
 


### PR DESCRIPTION
Added some `exec`s for runit to work properly.
Without `exec` the command runs as a new process and runit monitors the PID of the `run` script instead.

The issue was:
```
$ docker exec -it graphite bash
root@971b886696d9:/# sv status carbon    
run: carbon: (pid 35) 9s
root@971b886696d9:/# ps aux | grep carbon-cache
root        39  0.3  0.1 146236 20016 ?        Sl   13:54   0:00 /usr/bin/python /opt/graphite/bin/carbon-cache.py start --debug
root@971b886696d9:/# sv stop carbon            
ok: down: carbon: 1s, normally up
root@971b886696d9:/# ps aux | grep carbon-cache
root        39  0.0  0.1 146368 20220 ?        Sl   13:54   0:00 /usr/bin/python /opt/graphite/bin/carbon-cache.py start --debug
```
