### PR TITLE
Update Dockerfile - install python-ldap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get -y --force-yes install vim\
  python-dev\
  python-flup\
  python-pip\
+ python-ldap\
  expect\
  git\
  memcached\


### PR DESCRIPTION
Install the python-ldap module which allows graphite-web to use an LDAP backend for authentication.