### PR TITLE
Must remove carbon's PID files before startup

### DIFF
--- a/conf/etc/service/carbon-aggregator/run
+++ b/conf/etc/service/carbon-aggregator/run
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+rm /opt/graphite/storage/carbon-aggregator-a.pid
 exec /usr/bin/python /opt/graphite/bin/carbon-aggregator.py start --debug 2>&1 >> /var/log/carbon-aggregator.log

--- a/conf/etc/service/carbon/run
+++ b/conf/etc/service/carbon/run
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+rm /opt/graphite/storage/carbon-cache-a.pid
 exec /usr/bin/python /opt/graphite/bin/carbon-cache.py start --debug 2>&1 >> /var/log/carbon.log


### PR DESCRIPTION
I use ansible for starting my docker containers and collectd data was coming to a halt. Ansible is rough with containers, I think it might kill them instead of doing clean shutdowns. In any case, I realized there were left behind PID files. I went through runit's docs and realized it had nothing to do with the PID files, carbon-cache/carbon-aggregator scripts manage their own PIDs EVEN when you use the `--debug` to put the process in the foreground. If the PID files is there the task just bails out.

Carbon does a bad thing to handle stale PID files. So here I propose we simply delete the PID files when in the runit script which starts carbon/carbon-aggregator. It's a one line fix.

The `rm -f` is used so it won't emit an error if the pid is missing.