### PR TITLE
Expose ports to host by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get clean\
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # defaults
-EXPOSE 80:80 2003-2004:2003-2004 2023-2024:2023-2024 8125:8125/udp 8126:8126
+EXPOSE 80 2003-2004 2023-2024 8125/udp 8126
 VOLUME ["/opt/graphite/conf", "/opt/graphite/storage", "/etc/nginx", "/opt/statsd", "/etc/logrotate.d", "/var/log"]
 WORKDIR /
 ENV HOME /root

--- a/README.md
+++ b/README.md
@@ -16,7 +16,15 @@ This image will have you running & collecting stats in just a few minutes.
 ## Quick Start
 
 ```sh
-docker run -d --name graphite --restart=always hopsoft/graphite-statsd
+docker run -d\
+ --name graphite\
+ --restart=always\
+ -p 80:80\
+ -p 2003-2004:2003-2004\
+ -p 2023-2024:2023-2024\
+ -p 8125:8125/udp\
+ -p 8126:8126\
+ hopsoft/graphite-statsd
 ```
 
 This starts a Docker container named: **graphite**
@@ -42,19 +50,6 @@ Host | Container | Service
 8125 |      8125 | [statsd](https://github.com/etsy/statsd/blob/master/docs/server.md)
 8126 |      8126 | [statsd admin](https://github.com/etsy/statsd/blob/v0.7.2/docs/admin_interface.md)
 
-**Note**: You can override the default port mappings by specifying them when starting the container.
-
-```sh
-docker run -d\
- --name graphite\
- --restart=always\
- -p 80:80\
- -p 2003-2004:2003-2004\
- -p 2023-2024:2023-2024\
- -p 8125:8125/udp\
- -p 8126:8126\
- hopsoft/graphite-statsd
-```
 
 ### Mounted Volumes
 


### PR DESCRIPTION
According to https://docs.docker.com/engine/reference/builder/#/expose:

EXPOSE does not make the ports of the container accessible to the host.

The current README seems to indicate that the ports will be accessible to the host, which they are not.