### PR TITLE
PID file cleanup

### DIFF
--- a/conf/opt/graphite/conf/carbon.conf
+++ b/conf/opt/graphite/conf/carbon.conf
@@ -30,6 +30,9 @@
 #
 #LOCAL_DATA_DIR = /opt/graphite/storage/whisper/
 
+# Create PID file in the right directory to avoid PID file clean up issue on the container.
+PID_DIR = /var/run/
+
 # Enable daily log rotation. If disabled, a kill -HUP can be used after a manual rotate
 ENABLE_LOGROTATION = True
 


### PR DESCRIPTION
This PR will Resolve #59, as leaving the PID file path in the storage path may lead to cleanup issue if the docker container stops unexpectedly. This issue can be reproduced easily when the storage path is mounted outside the container (I suppose this is the most used case)
