### PR TITLE
Fix Django Admin CSS not showing up

### DIFF
--- a/conf/etc/nginx/sites-enabled/graphite-statsd.conf
+++ b/conf/etc/nginx/sites-enabled/graphite-statsd.conf
@@ -8,6 +8,14 @@ server {
     alias /usr/local/lib/python2.7/dist-packages/django/contrib/admin/media/;
   }
 
+  location /admin/auth/admin {
+    alias /usr/local/lib/python2.7/dist-packages/django/contrib/admin/static/admin;
+  }
+
+  location /admin/auth/user/admin {
+    alias /usr/local/lib/python2.7/dist-packages/django/contrib/admin/static/admin;
+  }
+
   location / {
     # checks for static file, if not found proxy to app
     try_files \$uri @app;


### PR DESCRIPTION
The user admin pages lost their static files, and triggered invalid mime type errors in the browser.