### PR TITLE
VOLUME and docker volume plugins don't mix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,6 @@ RUN apt-get clean\
 
 # defaults
 EXPOSE 80 2003-2004 2023-2024 8125/udp 8126
-VOLUME ["/opt/graphite/conf", "/opt/graphite/storage", "/etc/nginx", "/opt/statsd", "/etc/logrotate.d", "/var/log"]
 WORKDIR /
 ENV HOME /root
 CMD ["/sbin/my_init"]


### PR DESCRIPTION
When using a docker volume plugin, the volumes get created at run time, and get mounted over the directories listed in VOLUME, so none of the installed files are there any more!

All I did was remove the VOLUME directive in Dockerfile.