### PR TITLE
Add environment vars to configure Memcached on Graphite

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,30 @@ docker run -d\
 **Note**: The container will initialize properly if you mount empty volumes at
           `/opt/graphite`, `/opt/graphite/conf`, `/opt/graphite/storage`, or `/opt/statsd`
 
+## Memcached config
+
+If you have a Memcached server running, and want to Graphite use it, you can do it using environment variables, like this:
+
+```
+docker run -d\
+ --name graphite\
+ --restart=always\
+ -p 80:80\
+ -p 2003-2004:2003-2004\
+ -p 2023-2024:2023-2024\
+ -p 8125:8125/udp\
+ -p 8126:8126\
+ -e "MEMCACHE_HOST=127.0.0.1:11211"\  # Memcached host. Separate by comma more than one servers.
+ -e "CACHE_DURATION=60"\              # in seconds
+ hopsoft/graphite-statsd
+```
+
+Also, you can specify more than one memcached server, using commas:
+
+```
+-e "MEMCACHE_HOST=127.0.0.1:11211,10.0.0.1:11211"
+```
+
 ## Additional Reading
 
 * [Introduction to Docker](http://docs.docker.io/#introduction)

--- a/conf/opt/graphite/webapp/graphite/local_settings.py
+++ b/conf/opt/graphite/webapp/graphite/local_settings.py
@@ -202,5 +202,14 @@
 # MIDDLEWARE_CLASSES or APPS
 #from graphite.app_settings import *
 
+import os
+
 LOG_DIR = '/var/log/graphite'
 SECRET_KEY = '$(date +%s | sha256sum | base64 | head -c 64)'
+
+if (os.getenv("MEMCACHE_HOST") is not None):
+    MEMCACHE_HOSTS = os.getenv("MEMCACHE_HOST").split(",")
+
+if (os.getenv("DEFAULT_CACHE_DURATION") is not None):
+    DEFAULT_CACHE_DURATION = int(os.getenv("CACHE_DURATION"))
+


### PR DESCRIPTION
This allows to configure the Memcached options to Graphite, using environment variables, that can be easily added to the container with the `-e "ENVVAR=VALUE"` option to the `docker run` command like this:

```sh
docker run -d\
--name graphite\
--restart=always\
-p 80:80\
-p 2003-2004:2003-2004\
-p 2023-2024:2023-2024\
-p 8125:8125/udp\
-p 8126:8126\
-e "MEMCACHE_HOST=127.0.0.1:11211"\  # Memcached host. Separate by comma more than one servers.
-e "CACHE_DURATION=60"\              # in seconds
hopsoft/graphite-statsd
```

Note that this only allows the config to be used by Graphite, this NOT installs a Memcached server in the container.

Also, you can specify more than one memcached server, using commas:
`-e "MEMCACHE_HOST=127.0.0.1:11211,10.0.0.1:11211"`