### PR TITLE
Change example graphite command to use 127.0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Built using [Phusion's base image](https://github.com/phusion/baseimage-docker).
 Let's fake some stats with a random counter to prove things are working.
 
 ```sh
-while true; do echo -n "example:$((RANDOM % 100))|c" | nc -w 1 -u localhost 8125; done
+while true; do echo -n "example:$((RANDOM % 100))|c" | nc -w 1 -u 127.0.0.1 8125; done
 ```
 
 ### Visualize the Data


### PR DESCRIPTION
localhost can be resolved to an ipv6 address. Ensuring that ipv4 is used by using the ip address works around some issues people are having in https://github.com/hopsoft/docker-graphite-statsd/issues/64