### PR TITLE
Add carbon-relay to started processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,53 +1,55 @@
-FROM phusion/baseimage:0.9.18
-MAINTAINER Nathan Hopkins <natehop@gmail.com>
+FROM phusion/baseimage:0.9.22
+MAINTAINER Denys Zhdanov <denis.zhdanov@gmail.com>
 
-#RUN echo deb http://archive.ubuntu.com/ubuntu $(lsb_release -cs) main universe > /etc/apt/sources.list.d/universe.list
-RUN apt-get -y update\
- && apt-get -y upgrade
+RUN apt-get -y update \
+  && apt-get -y upgrade \
+  && apt-get -y --force-yes install vim \
+  nginx \
+  python-dev \
+  python-flup \
+  python-pip \
+  python-ldap \
+  expect \
+  git \
+  memcached \
+  sqlite3 \
+  libffi-dev \
+  libcairo2 \
+  libcairo2-dev \
+  python-cairo \
+  python-rrdtool \
+  pkg-config \
+  nodejs \
+  && rm -rf /var/lib/apt/lists/*
 
-# dependencies
-RUN apt-get -y --force-yes install vim\
- nginx\
- python-dev\
- python-flup\
- python-pip\
- python-ldap\
- expect\
- git\
- memcached\
- sqlite3\
- libcairo2\
- libcairo2-dev\
- python-cairo\
- python-rrdtool\
- pkg-config\
- nodejs
-
-# python dependencies
-RUN pip install django==1.5.12\
- python-memcached==1.53\
- django-tagging==0.3.1\
- twisted==11.1.0\
- txAMQP==0.6.2
-
-# install graphite
-RUN git clone -b 0.9.15 --depth 1 https://github.com/graphite-project/graphite-web.git /usr/local/src/graphite-web
-WORKDIR /usr/local/src/graphite-web
-RUN python ./setup.py install
-ADD conf/opt/graphite/conf/*.conf /opt/graphite/conf/
-ADD conf/opt/graphite/webapp/graphite/local_settings.py /opt/graphite/webapp/graphite/local_settings.py
-ADD conf/opt/graphite/webapp/graphite/app_settings.py /opt/graphite/webapp/graphite/app_settings.py
-RUN python /opt/graphite/webapp/graphite/manage.py collectstatic --noinput
+# fix python dependencies (LTS Django and newer memcached/txAMQP)
+RUN pip install django==1.8.18 \
+  python-memcached==1.53 \
+  txAMQP==0.6.2 \
+  && pip install --upgrade pip
 
 # install whisper
-RUN git clone -b 0.9.15 --depth 1 https://github.com/graphite-project/whisper.git /usr/local/src/whisper
+RUN git clone -b 1.0.2 --depth 1 https://github.com/graphite-project/whisper.git /usr/local/src/whisper
 WORKDIR /usr/local/src/whisper
 RUN python ./setup.py install
 
 # install carbon
-RUN git clone -b 0.9.15 --depth 1 https://github.com/graphite-project/carbon.git /usr/local/src/carbon
+RUN git clone -b 1.0.2 --depth 1 https://github.com/graphite-project/carbon.git /usr/local/src/carbon
 WORKDIR /usr/local/src/carbon
-RUN python ./setup.py install
+RUN pip install -r requirements.txt \
+  && python ./setup.py install
+
+# install graphite
+RUN git clone -b 1.0.2 --depth 1 https://github.com/graphite-project/graphite-web.git /usr/local/src/graphite-web
+WORKDIR /usr/local/src/graphite-web
+RUN pip install -r requirements.txt \
+  && python ./setup.py install
+ADD conf/opt/graphite/conf/*.conf /opt/graphite/conf/
+ADD conf/opt/graphite/webapp/graphite/local_settings.py /opt/graphite/webapp/graphite/local_settings.py
+ADD conf/opt/graphite/webapp/graphite/app_settings.py /opt/graphite/webapp/graphite/app_settings.py
+WORKDIR /opt/graphite/webapp
+RUN mkdir -p /var/log/graphite/ \
+  && PYTHONPATH=/opt/graphite/webapp django-admin.py collectstatic --noinput --settings=graphite.settings
 
 # install statsd
 RUN git clone -b v0.7.2 https://github.com/etsy/statsd.git /opt/statsd
@@ -60,7 +62,9 @@ ADD conf/etc/nginx/sites-enabled/graphite-statsd.conf /etc/nginx/sites-enabled/g
 
 # init django admin
 ADD conf/usr/local/bin/django_admin_init.exp /usr/local/bin/django_admin_init.exp
-RUN /usr/local/bin/django_admin_init.exp
+ADD conf/usr/local/bin/manage.sh /usr/local/bin/manage.sh
+RUN chmod +x /usr/local/bin/manage.sh \
+  && /usr/local/bin/django_admin_init.exp
 
 # logging support
 RUN mkdir -p /var/log/carbon /var/log/graphite /var/log/nginx

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This repo was based on [@hopsoft's](https://github.com/hopsoft/) [docker-graphite-statsd](https://github.com/hopsoft/docker-graphite-statsd) docker image and was used as base for "official" Docker image with his permission. Also, it contains parts of famous [@obfuscurity's](https://github.com/obfuscurity/) [synthesize](https://github.com/obfuscurity/synthesize) Graphite installer. Thanks a lot, Natan and Jason!
+This repo was based on [@hopsoft's](https://github.com/hopsoft/) [docker-graphite-statsd](https://github.com/hopsoft/docker-graphite-statsd) docker image and was used as base for "official" Graphite docker image with his permission. Also, it contains parts of famous [@obfuscurity's](https://github.com/obfuscurity/) [synthesize](https://github.com/obfuscurity/synthesize) Graphite installer. Thanks a lot, Natan and Jason!
 
 # Docker Image for Graphite & Statsd
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Docker Pulls](https://img.shields.io/docker/pulls/hopsoft/graphite-statsd.svg?style=flat)](https://hub.docker.com/r/hopsoft/graphite-statsd/)
+WIP!!! Do not use yet!!!
 
-[![Sponsor](https://app.codesponsor.io/embed/QMSjMHrtPhvfmCnk5Hbikhhr/hopsoft/docker-graphite-statsd.svg)](https://app.codesponsor.io/link/QMSjMHrtPhvfmCnk5Hbikhhr/hopsoft/docker-graphite-statsd)
+This repo was based on [@hopsoft's](https://github.com/hopsoft/) [docker-graphite-statsd](https://github.com/hopsoft/docker-graphite-statsd) docker image and was used as base for "official" Docker image with his permission. Also, it contains parts of famous [@obfuscurity's](https://github.com/obfuscurity/) [synthesize](https://github.com/obfuscurity/synthesize) Graphite installer. Thanks a lot, Natan and Jason!
 
 # Docker Image for Graphite & Statsd
 

--- a/README.md
+++ b/README.md
@@ -190,5 +190,5 @@ Also, you can specify more than one memcached server, using commas:
 
 Build the image yourself.
 
-1. `git clone https://github.com/hopsoft/docker-graphite-statsd.git`
-1. `docker build -t hopsoft/graphite-statsd .`
+1. `git clone https://github.com/graphite-project/docker-graphite-statsd.git`
+1. `docker build -t graphiteapp/graphite-statsd .`

--- a/README.md
+++ b/README.md
@@ -192,3 +192,13 @@ Build the image yourself.
 
 1. `git clone https://github.com/graphite-project/docker-graphite-statsd.git`
 1. `docker build -t graphiteapp/graphite-statsd .`
+
+Alternate versions can be specified via `--build-arg`:
+
+* `version` will set the version/branch used for graphite-web, carbon & whisper
+* `graphite_version`, `carbon_version` & `whisper_version` set the version/branch used for individual components
+* `statsd_version` sets the version/branch used for statsd (note statsd version is prefixed with v)
+
+To build an image from latest graphite master, run:
+
+`docker build -t graphiteapp/graphite-statsd . --build-arg version=master`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-WIP!!! Do not use yet!!!
-
 This repo was based on [@hopsoft's](https://github.com/hopsoft/) [docker-graphite-statsd](https://github.com/hopsoft/docker-graphite-statsd) docker image and was used as base for "official" Docker image with his permission. Also, it contains parts of famous [@obfuscurity's](https://github.com/obfuscurity/) [synthesize](https://github.com/obfuscurity/synthesize) Graphite installer. Thanks a lot, Natan and Jason!
 
 # Docker Image for Graphite & Statsd
@@ -20,7 +18,7 @@ docker run -d\
  -p 2023-2024:2023-2024\
  -p 8125:8125/udp\
  -p 8126:8126\
- hopsoft/graphite-statsd
+ graphiteapp/graphite-statsd
 ```
 
 This starts a Docker container named: **graphite**
@@ -149,7 +147,7 @@ docker run -d\
  -v /path/to/graphite/configs:/opt/graphite/conf\
  -v /path/to/graphite/data:/opt/graphite/storage\
  -v /path/to/statsd:/opt/statsd\
- hopsoft/graphite-statsd
+ graphiteapp/graphite-statsd
 ```
 
 **Note**: The container will initialize properly if you mount empty volumes at
@@ -170,7 +168,7 @@ docker run -d\
  -p 8126:8126\
  -e "MEMCACHE_HOST=127.0.0.1:11211"\  # Memcached host. Separate by comma more than one servers.
  -e "CACHE_DURATION=60"\              # in seconds
- hopsoft/graphite-statsd
+ graphiteapp/graphite-statsd
 ```
 
 Also, you can specify more than one memcached server, using commas:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-This repo was based on [@hopsoft's](https://github.com/hopsoft/) [docker-graphite-statsd](https://github.com/hopsoft/docker-graphite-statsd) docker image and was used as base for "official" Graphite docker image with his permission. Also, it contains parts of famous [@obfuscurity's](https://github.com/obfuscurity/) [synthesize](https://github.com/obfuscurity/synthesize) Graphite installer. Thanks a lot, Natan and Jason!
+This repo was based on [@hopsoft's](https://github.com/hopsoft/) [docker-graphite-statsd](https://github.com/hopsoft/docker-graphite-statsd) docker image and was used as base for "official" Graphite docker image with his permission. Also, it contains parts of famous [@obfuscurity's](https://github.com/obfuscurity/) [synthesize](https://github.com/obfuscurity/synthesize) Graphite installer. Thanks a lot, Nathan and Jason!
+
+Any suggestions / patches etc. are welcome!
 
 # Docker Image for Graphite & Statsd
 

--- a/conf/etc/my_init.d/01_conf_init.sh
+++ b/conf/etc/my_init.d/01_conf_init.sh
@@ -12,7 +12,7 @@ graphite_conf_dir_contents=$(find /opt/graphite/conf -mindepth 1 -print -quit)
 graphite_webapp_dir_contents=$(find /opt/graphite/webapp/graphite -mindepth 1 -print -quit)
 graphite_storage_dir_contents=$(find /opt/graphite/storage -mindepth 1 -print -quit)
 if [[ -z $graphite_dir_contents ]]; then
-  git clone -b 1.0.2 --depth 1 https://github.com/graphite-project/graphite-web.git /usr/local/src/graphite-web
+  # git clone -b 1.0.2 --depth 1 https://github.com/graphite-project/graphite-web.git /usr/local/src/graphite-web
   cd /usr/local/src/graphite-web && python ./setup.py install
 fi
 if [[ -z $graphite_storage_dir_contents ]]; then

--- a/conf/etc/my_init.d/01_conf_init.sh
+++ b/conf/etc/my_init.d/01_conf_init.sh
@@ -12,7 +12,7 @@ graphite_conf_dir_contents=$(find /opt/graphite/conf -mindepth 1 -print -quit)
 graphite_webapp_dir_contents=$(find /opt/graphite/webapp/graphite -mindepth 1 -print -quit)
 graphite_storage_dir_contents=$(find /opt/graphite/storage -mindepth 1 -print -quit)
 if [[ -z $graphite_dir_contents ]]; then
-  git clone -b 0.9.15 --depth 1 https://github.com/graphite-project/graphite-web.git /usr/local/src/graphite-web
+  git clone -b 1.0.2 --depth 1 https://github.com/graphite-project/graphite-web.git /usr/local/src/graphite-web
   cd /usr/local/src/graphite-web && python ./setup.py install
 fi
 if [[ -z $graphite_storage_dir_contents ]]; then

--- a/conf/etc/nginx/sites-enabled/graphite-statsd.conf
+++ b/conf/etc/nginx/sites-enabled/graphite-statsd.conf
@@ -1,6 +1,6 @@
 server {
   listen 80;
-  root /opt/graphite/webapp/content;
+  root /opt/graphite/static;
   index index.html;
 
   location /media {
@@ -17,17 +17,15 @@ server {
   }
 
   location / {
-    # checks for static file, if not found proxy to app
-    try_files \$uri @app;
-  }
+    proxy_pass http://localhost:8080;
+    proxy_set_header  Host      $host;
+    proxy_set_header  X-Real-IP $remote_addr;
+    proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
 
-  location @app {
-    include fastcgi_params;
-    fastcgi_split_path_info ^()(.*)$;
-    fastcgi_pass 127.0.0.1:8080;
     add_header 'Access-Control-Allow-Origin' '*';
     add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
     add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type';
     add_header 'Access-Control-Allow-Credentials' 'true';
   }
+
 }

--- a/conf/etc/service/graphite/run
+++ b/conf/etc/service/graphite/run
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-exec /usr/bin/python /opt/graphite/webapp/graphite/manage.py runfcgi daemonize=false host=127.0.0.1 port=8080
-
+export PYTHONPATH=/opt/graphite/webapp && exec /usr/local/bin/gunicorn wsgi --workers=4 --bind=127.0.0.1:8080 --log-file=/var/log/gunicorn.log --preload --pythonpath=/opt/graphite/webapp/graphite

--- a/conf/opt/graphite/conf/carbon.conf
+++ b/conf/opt/graphite/conf/carbon.conf
@@ -8,18 +8,18 @@
 #                          Defaults to ../
 #   GRAPHITE_CONF_DIR    - Configuration directory (where this file lives).
 #                          Defaults to $GRAPHITE_ROOT/conf/
-#   GRAPHITE_STORAGE_DIR - Storage directory for whipser/rrd/log/pid files.
+#   GRAPHITE_STORAGE_DIR - Storage directory for whisper/rrd/log/pid files.
 #                          Defaults to $GRAPHITE_ROOT/storage/
 #
 # To change other directory paths, add settings to this file. The following
 # configuration variables are available with these default values:
 #
 #   STORAGE_DIR    = $GRAPHITE_STORAGE_DIR
-#   LOCAL_DATA_DIR = STORAGE_DIR/whisper/
-#   WHITELISTS_DIR = STORAGE_DIR/lists/
-#   CONF_DIR       = STORAGE_DIR/conf/
-#   LOG_DIR        = STORAGE_DIR/log/
-#   PID_DIR        = STORAGE_DIR/
+#   LOCAL_DATA_DIR = %(STORAGE_DIR)s/whisper/
+#   WHITELISTS_DIR = %(STORAGE_DIR)s/lists/
+#   CONF_DIR       = %(STORAGE_DIR)s/conf/
+#   LOG_DIR        = %(STORAGE_DIR)s/log/
+#   PID_DIR        = %(STORAGE_DIR)s/
 #
 # For FHS style directory structures, use:
 #
@@ -30,20 +30,30 @@
 #
 #LOCAL_DATA_DIR = /opt/graphite/storage/whisper/
 
-# Enable daily log rotation. If disabled, a kill -HUP can be used after a manual rotate
+# Specify the database library used to store metric data on disk. Each database
+# may have configurable options to change the behaviour of how it writes to
+# persistent storage.
+#
+# whisper - Fixed-size database, similar in design and purpose to RRD. This is
+# the default storage backend for carbon and the most rigorously tested.
+#
+# ceres - Experimental alternative database that supports storing data in sparse
+# files of arbitrary fixed-size resolutions.
+DATABASE = whisper
+
+# Enable daily log rotation. If disabled, a new file will be opened whenever the log file path no
+# longer exists (i.e. it is removed or renamed)
 ENABLE_LOGROTATION = True
 
 # Specify the user to drop privileges to
-# If this is blank carbon runs as the user that invokes it
+# If this is blank carbon-cache runs as the user that invokes it
 # This user must have write access to the local data directory
 USER =
-#
-# NOTE: The above settings must be set under [relay] and [aggregator]
-#       to take effect for those daemons as well
 
 # Limit the size of the cache to avoid swapping or becoming CPU bound.
 # Sorts and serving cache queries gets more expensive as the cache grows.
 # Use the value "inf" (infinity) for an unlimited cache size.
+# value should be an integer number of metric datapoints.
 MAX_CACHE_SIZE = inf
 
 # Limits the number of whisper update_many() calls per second, which effectively
@@ -60,14 +70,18 @@ MAX_UPDATES_PER_SECOND = 500
 # MAX_UPDATES_PER_SECOND_ON_SHUTDOWN = 1000
 
 # Softly limits the number of whisper files that get created each minute.
-# Setting this value low (like at 50) is a good way to ensure your graphite
+# Setting this value low (e.g. 50) is a good way to ensure that your carbon
 # system will not be adversely impacted when a bunch of new metrics are
-# sent to it. The trade off is that it will take much longer for those metrics'
-# database files to all get created and thus longer until the data becomes usable.
-# Setting this value high (like "inf" for infinity) will cause graphite to create
-# the files quickly but at the risk of slowing I/O down considerably for a while.
+# sent to it. The trade off is that any metrics received in excess of this
+# value will be silently dropped, and the whisper file will not be created
+# until such point as a subsequent metric is received and fits within the
+# defined rate limit. Setting this value high (like "inf" for infinity) will
+# cause carbon to create the files quickly but at the risk of increased I/O.
 MAX_CREATES_PER_MINUTE = 50
 
+# Set the interface and port for the line (plain text) listener.  Setting the
+# interface to 0.0.0.0 listens on all interfaces.  Port can be set to 0 to
+# disable this listener if it is not required.
 LINE_RECEIVER_INTERFACE = 0.0.0.0
 LINE_RECEIVER_PORT = 2003
 
@@ -78,11 +92,17 @@ ENABLE_UDP_LISTENER = False
 UDP_RECEIVER_INTERFACE = 0.0.0.0
 UDP_RECEIVER_PORT = 2003
 
+# Set the interface and port for the pickle listener.  Setting the interface to
+# 0.0.0.0 listens on all interfaces.  Port can be set to 0 to disable this
+# listener if it is not required.
 PICKLE_RECEIVER_INTERFACE = 0.0.0.0
 PICKLE_RECEIVER_PORT = 2004
 
-# Set to false to disable logging of successful connections
-LOG_LISTENER_CONNECTIONS = True
+# Limit the number of open connections the receiver can handle as any time.
+# Default is no limit. Setting up a limit for sites handling high volume
+# traffic may be recommended to avoid running out of TCP memory or having
+# thousands of TCP connections reduce the throughput of the service.
+#MAX_RECEIVER_CONNECTIONS = inf
 
 # Per security concerns outlined in Bug #817247 the pickle receiver
 # will use a more secure and slightly less efficient unpickler.
@@ -98,13 +118,19 @@ CACHE_QUERY_PORT = 7002
 # data until the cache size falls below 95% MAX_CACHE_SIZE.
 USE_FLOW_CONTROL = True
 
-# By default, carbon-cache will log every whisper update and cache hit. This can be excessive and
-# degrade performance if logging on the same volume as the whisper data is stored.
+# If enabled this setting is used to timeout metric client connection if no
+# metrics have been sent in specified time in seconds 
+#METRIC_CLIENT_IDLE_TIMEOUT = None
+
+# By default, carbon-cache will log every whisper update and cache hit.
+# This can be excessive and degrade performance if logging on the same
+# volume as the whisper data is stored.
+LOG_CREATES = False
 LOG_UPDATES = False
 LOG_CACHE_HITS = False
-LOG_CACHE_QUEUE_SORTS = True
+LOG_CACHE_QUEUE_SORTS = False
 
-# The thread that writes metrics to disk can use on of the following strategies
+# The thread that writes metrics to disk can use one of the following strategies
 # determining the order in which metrics are removed from cache and flushed to
 # disk. The default option preserves the same behavior as has been historically
 # available in version 0.9.10.
@@ -152,12 +178,61 @@ WHISPER_FALLOCATE_CREATE = True
 
 # Enabling this option will cause Whisper to lock each Whisper file it writes
 # to with an exclusive lock (LOCK_EX, see: man 2 flock). This is useful when
-# multiple carbon-cache daemons are writing to the same files
+# multiple carbon-cache daemons are writing to the same files.
 # WHISPER_LOCK_WRITES = False
 
+# On systems which has a large number of metrics, an amount of Whisper write(2)'s
+# pageback sometimes cause disk thrashing due to memory shortage, so that abnormal
+# disk reads occur. Enabling this option makes it possible to decrease useless 
+# page cache memory by posix_fadvise(2) with POSIX_FADVISE_RANDOM option.
+# WHISPER_FADVISE_RANDOM = False
+
+# By default all nodes stored in Ceres are cached in memory to improve the
+# throughput of reads and writes to underlying slices. Turning this off will
+# greatly reduce memory consumption for databases with millions of metrics, at
+# the cost of a steep increase in disk i/o, approximately an extra two os.stat
+# calls for every read and write. Reasons to do this are if the underlying
+# storage can handle stat() with practically zero cost (SSD, NVMe, zRAM).
+# Valid values are:
+#       all - all nodes are cached
+#      none - node caching is disabled
+# CERES_NODE_CACHING_BEHAVIOR = all
+
+# Ceres nodes can have many slices and caching the right ones can improve
+# performance dramatically. Note that there are many trade-offs to tinkering
+# with this, and unless you are a ceres developer you *really* should not
+# mess with this. Valid values are:
+#    latest - only the most recent slice is cached
+#       all - all slices are cached
+#      none - slice caching is disabled
+# CERES_SLICE_CACHING_BEHAVIOR = latest
+
+# If a Ceres node accumulates too many slices, performance can suffer.
+# This can be caused by intermittently reported data. To mitigate
+# slice fragmentation there is a tolerance for how much space can be
+# wasted within a slice file to avoid creating a new one. That tolerance
+# level is determined by MAX_SLICE_GAP, which is the number of consecutive
+# null datapoints allowed in a slice file.
+# If you set this very low, you will waste less of the *tiny* bit disk space
+# that this feature wastes, and you will be prone to performance problems
+# caused by slice fragmentation, which can be pretty severe.
+# If you set this really high, you will waste a bit more disk space (each
+# null datapoint wastes 8 bytes, but keep in mind your filesystem's block
+# size). If you suffer slice fragmentation issues, you should increase this or
+# run the ceres-maintenance defrag plugin more often. However you should not
+# set it to be huge because then if a large but allowed gap occurs it has to
+# get filled in, which means instead of a simple 8-byte write to a new file we
+# could end up doing an (8 * MAX_SLICE_GAP)-byte write to the latest slice.
+# CERES_MAX_SLICE_GAP = 80
+
+# Enabling this option will cause Ceres to lock each Ceres file it writes to
+# to with an exclusive lock (LOCK_EX, see: man 2 flock). This is useful when
+# multiple carbon-cache daemons are writing to the same files.
+# CERES_LOCK_WRITES = False
+
 # Set this to True to enable whitelisting and blacklisting of metrics in
-# CONF_DIR/whitelist and CONF_DIR/blacklist. If the whitelist is missing or
-# empty, all metrics will pass through
+# CONF_DIR/whitelist.conf and CONF_DIR/blacklist.conf. If the whitelist is
+# missing or empty, all metrics will pass through
 # USE_WHITELIST = False
 
 # By default, carbon itself will log statistics (such as a count,
@@ -203,25 +278,28 @@ WHISPER_FALLOCATE_CREATE = True
 # Example: store everything
 # BIND_PATTERNS = #
 
+GRAPHITE_URL = http://127.0.0.1:80
+
+TAG_UPDATE_INTERVAL = 1
+
 # To configure special settings for the carbon-cache instance 'b', uncomment this:
 #[cache:b]
 #LINE_RECEIVER_PORT = 2103
 #PICKLE_RECEIVER_PORT = 2104
 #CACHE_QUERY_PORT = 7102
 # and any other settings you want to customize, defaults are inherited
-# from [carbon] section.
+# from the [cache] section.
 # You can then specify the --instance=b option to manage this instance
-
-
+#
+# In order to turn off logging of successful connections for the line
+# receiver, set this to False
+# LOG_LISTENER_CONN_SUCCESS = True
 
 [relay]
 LINE_RECEIVER_INTERFACE = 0.0.0.0
 LINE_RECEIVER_PORT = 2013
 PICKLE_RECEIVER_INTERFACE = 0.0.0.0
 PICKLE_RECEIVER_PORT = 2014
-
-# Set to false to disable logging of successful connections
-LOG_LISTENER_CONNECTIONS = True
 
 # Carbon-relay has several options for metric routing controlled by RELAY_METHOD
 #
@@ -237,11 +315,23 @@ LOG_LISTENER_CONNECTIONS = True
 # instance.
 # Enable this for carbon-relays that send to a group of carbon-aggregators
 #RELAY_METHOD = aggregated-consistent-hashing
+#
+# You can also use fast-hashing and fast-aggregated-hashing which are in O(1)
+# and will always redirect the metrics to the same destination but do not try
+# to minimize rebalancing when the list of destinations is changing.
 RELAY_METHOD = rules
 
 # If you use consistent-hashing you can add redundancy by replicating every
 # datapoint to more than one machine.
 REPLICATION_FACTOR = 1
+
+# For REPLICATION_FACTOR >=2, set DIVERSE_REPLICAS to True to guarantee replicas
+# across distributed hosts. With this setting disabled, it's possible that replicas
+# may be sent to different caches on the same host. This has been the default 
+# behavior since introduction of 'consistent-hashing' relay method.
+# Note that enabling this on an existing pre-0.9.14 cluster will require rebalancing
+# your metrics across the cluster nodes using a tool like Carbonate.
+#DIVERSE_REPLICAS = True
 
 # This is a list of carbon daemons we will send any relayed or
 # generated metrics to. The default provided would send to a single
@@ -261,20 +351,55 @@ REPLICATION_FACTOR = 1
 # must be defined in this list
 DESTINATIONS = 127.0.0.1:2004
 
-# This defines the maximum "message size" between carbon daemons.
-# You shouldn't need to tune this unless you really know what you're doing.
-MAX_DATAPOINTS_PER_MESSAGE = 500
+# This is the maximum number of datapoints that can be queued up
+# for a single destination. Once this limit is hit, we will
+# stop accepting new data if USE_FLOW_CONTROL is True, otherwise
+# we will drop any subsequently received datapoints.
 MAX_QUEUE_SIZE = 10000
+
+# This defines the maximum "message size" between carbon daemons.  If
+# your queue is large, setting this to a lower number will cause the
+# relay to forward smaller discrete chunks of stats, which may prevent
+# overloading on the receiving side after a disconnect.
+MAX_DATAPOINTS_PER_MESSAGE = 500
+
+# Limit the number of open connections the receiver can handle as any time.
+# Default is no limit. Setting up a limit for sites handling high volume
+# traffic may be recommended to avoid running out of TCP memory or having
+# thousands of TCP connections reduce the throughput of the service.
+#MAX_RECEIVER_CONNECTIONS = inf
+
+# Specify the user to drop privileges to
+# If this is blank carbon-relay runs as the user that invokes it
+# USER =
+
+# This is the percentage that the queue must be empty before it will accept
+# more messages.  For a larger site, if the queue is very large it makes sense
+# to tune this to allow for incoming stats.  So if you have an average
+# flow of 100k stats/minute, and a MAX_QUEUE_SIZE of 3,000,000, it makes sense
+# to allow stats to start flowing when you've cleared the queue to 95% since
+# you should have space to accommodate the next minute's worth of stats
+# even before the relay incrementally clears more of the queue
+QUEUE_LOW_WATERMARK_PCT = 0.8
+
+# To allow for batch efficiency from the pickle protocol and to benefit from
+# other batching advantages, all writes are deferred by putting them into a queue,
+# and then the queue is flushed and sent a small fraction of a second later.
+TIME_TO_DEFER_SENDING = 0.0001
 
 # Set this to False to drop datapoints when any send queue (sending datapoints
 # to a downstream carbon daemon) hits MAX_QUEUE_SIZE. If this is True (the
 # default) then sockets over which metrics are received will temporarily stop accepting
-# data until the send queues fall below 80% MAX_QUEUE_SIZE.
+# data until the send queues fall below QUEUE_LOW_WATERMARK_PCT * MAX_QUEUE_SIZE.
 USE_FLOW_CONTROL = True
 
+# If enabled this setting is used to timeout metric client connection if no
+# metrics have been sent in specified time in seconds 
+#METRIC_CLIENT_IDLE_TIMEOUT = None
+
 # Set this to True to enable whitelisting and blacklisting of metrics in
-# CONF_DIR/whitelist and CONF_DIR/blacklist. If the whitelist is missing or
-# empty, all metrics will pass through
+# CONF_DIR/whitelist.conf and CONF_DIR/blacklist.conf. If the whitelist is
+# missing or empty, all metrics will pass through
 # USE_WHITELIST = False
 
 # By default, carbon itself will log statistics (such as a count,
@@ -282,7 +407,40 @@ USE_FLOW_CONTROL = True
 # seconds. Set CARBON_METRIC_INTERVAL to 0 to disable instrumentation
 # CARBON_METRIC_PREFIX = carbon
 # CARBON_METRIC_INTERVAL = 60
+#
+# In order to turn off logging of successful connections for the line
+# receiver, set this to False
+# LOG_LISTENER_CONN_SUCCESS = True
 
+# If you're connecting from the relay to a destination that's over the
+# internet or similarly iffy connection, a backlog can develop because
+# of internet weather conditions, e.g. acks getting lost or similar issues.
+# To deal with that, you can enable USE_RATIO_RESET which will let you
+# re-set the connection to an individual destination.  Defaults to being off.
+USE_RATIO_RESET=False
+
+# When there is a small number of stats flowing, it's not desirable to
+# perform any actions based on percentages - it's just too "twitchy".
+MIN_RESET_STAT_FLOW=1000
+
+# When the ratio of stats being sent in a reporting interval is far
+# enough from 1.0, we will disconnect the socket and reconnecto to
+# clear out queued stats.  The default ratio of 0.9 indicates that 10%
+# of stats aren't being delivered within one CARBON_METRIC_INTERVAL
+# (default of 60 seconds), which can lead to a queue backup.  Under
+# some circumstances re-setting the connection can fix this, so
+# set this according to your tolerance, and look in the logs for
+# "resetConnectionForQualityReasons" to observe whether this is kicking
+# in when your sent queue is building up.
+MIN_RESET_RATIO=0.9
+
+# The minimum time between resets.  When a connection is re-set, we
+# need to wait before another reset is performed.
+# (2*CARBON_METRIC_INTERVAL) + 1 second is the minimum time needed
+# before stats for the new connection will be available.  Setting this
+# below (2*CARBON_METRIC_INTERVAL) + 1 second will result in a lot of
+# reset connections for no good reason.
+MIN_RESET_INTERVAL=121
 
 [aggregator]
 LINE_RECEIVER_INTERFACE = 0.0.0.0
@@ -291,13 +449,16 @@ LINE_RECEIVER_PORT = 2023
 PICKLE_RECEIVER_INTERFACE = 0.0.0.0
 PICKLE_RECEIVER_PORT = 2024
 
-# Set to false to disable logging of successful connections
-LOG_LISTENER_CONNECTIONS = True
-
 # If set true, metric received will be forwarded to DESTINATIONS in addition to
 # the output of the aggregation rules. If set false the carbon-aggregator will
 # only ever send the output of aggregation.
 FORWARD_ALL = True
+
+# Filenames of the configuration files to use for this instance of aggregator.
+# Filenames are relative to CONF_DIR.
+#
+# AGGREGATION_RULES = aggregation-rules.conf
+# REWRITE_RULES = rewrite-rules.conf
 
 # This is a list of carbon daemons we will send any relayed or
 # generated metrics to. The default provided would send to a single
@@ -330,6 +491,10 @@ MAX_QUEUE_SIZE = 10000
 # data until the send queues fall below 80% MAX_QUEUE_SIZE.
 USE_FLOW_CONTROL = True
 
+# If enabled this setting is used to timeout metric client connection if no
+# metrics have been sent in specified time in seconds 
+#METRIC_CLIENT_IDLE_TIMEOUT = None
+
 # This defines the maximum "message size" between carbon daemons.
 # You shouldn't need to tune this unless you really know what you're doing.
 MAX_DATAPOINTS_PER_MESSAGE = 500
@@ -338,6 +503,12 @@ MAX_DATAPOINTS_PER_MESSAGE = 500
 # each metric. Aggregation only happens for datapoints that fall in
 # the past MAX_AGGREGATION_INTERVALS * intervalSize seconds.
 MAX_AGGREGATION_INTERVALS = 5
+
+# Limit the number of open connections the receiver can handle as any time.
+# Default is no limit. Setting up a limit for sites handling high volume
+# traffic may be recommended to avoid running out of TCP memory or having
+# thousands of TCP connections reduce the throughput of the service.
+#MAX_RECEIVER_CONNECTIONS = inf
 
 # By default (WRITE_BACK_FREQUENCY = 0), carbon-aggregator will write back
 # aggregated data points once every rule.frequency seconds, on a per-rule basis.
@@ -348,8 +519,8 @@ MAX_AGGREGATION_INTERVALS = 5
 # WRITE_BACK_FREQUENCY = 0
 
 # Set this to True to enable whitelisting and blacklisting of metrics in
-# CONF_DIR/whitelist and CONF_DIR/blacklist. If the whitelist is missing or
-# empty, all metrics will pass through
+# CONF_DIR/whitelist.conf and CONF_DIR/blacklist.conf. If the whitelist is
+# missing or empty, all metrics will pass through
 # USE_WHITELIST = False
 
 # By default, carbon itself will log statistics (such as a count,
@@ -357,3 +528,15 @@ MAX_AGGREGATION_INTERVALS = 5
 # seconds. Set CARBON_METRIC_INTERVAL to 0 to disable instrumentation
 # CARBON_METRIC_PREFIX = carbon
 # CARBON_METRIC_INTERVAL = 60
+
+# In order to turn off logging of successful connections for the line
+# receiver, set this to False
+# LOG_LISTENER_CONN_SUCCESS = True
+
+# In order to turn off logging of metrics with no corresponding
+# aggregation rules receiver, set this to False
+# LOG_AGGREGATOR_MISSES = False
+
+# Specify the user to drop privileges to
+# If this is blank carbon-aggregator runs as the user that invokes it
+# USER =

--- a/conf/opt/graphite/conf/storage-schemas.conf
+++ b/conf/opt/graphite/conf/storage-schemas.conf
@@ -1,13 +1,22 @@
 # Schema definitions for Whisper files. Entries are scanned in order,
 # and first match wins. This file is scanned for changes every 60 seconds.
 #
-#  [name]
-#  pattern = regex
-#  retentions = timePerPoint:timeToStore, timePerPoint:timeToStore, ...
+# Definition Syntax:
+#
+#    [name]
+#    pattern = regex
+#    retentions = timePerPoint:timeToStore, timePerPoint:timeToStore, ...
+#
+# Remember: To support accurate aggregation from higher to lower resolution
+#           archives, the precision of a longer retention archive must be
+#           cleanly divisible by precision of next lower retention archive.
+#
+#           Valid:    60s:7d,300s:30d (300/60 = 5)
+#           Invalid:  180s:7d,300s:30d (300/180 = 3.333)
+#
 
 # Carbon's internal metrics. This entry should match what is specified in
 # CARBON_METRIC_PREFIX and CARBON_METRIC_INTERVAL settings
-
 [carbon]
 pattern = ^carbon\.
 retentions = 10s:6h,1m:90d

--- a/conf/opt/graphite/conf/storage-schemas.conf
+++ b/conf/opt/graphite/conf/storage-schemas.conf
@@ -10,8 +10,8 @@
 
 [carbon]
 pattern = ^carbon\.
-retentions = 10s:6h,1min:90d
+retentions = 10s:6h,1m:90d
 
 [default_1min_for_1day]
 pattern = .*
-retentions = 10s:6h,1min:6d,10min:1800d
+retentions = 10s:6h,1m:6d,10m:1800d

--- a/conf/opt/graphite/webapp/graphite/app_settings.py
+++ b/conf/opt/graphite/webapp/graphite/app_settings.py
@@ -14,31 +14,40 @@ limitations under the License."""
 
 # Django settings for graphite project.
 # DO NOT MODIFY THIS FILE DIRECTLY - use local_settings.py instead
-from django import VERSION as DJANGO_VERSION
 from os.path import dirname, join, abspath
 
-ADMINS = ()
-MANAGERS = ADMINS
-
-TEMPLATE_DIRS = (
-  join(dirname( abspath(__file__) ), 'templates'),
-)
 
 #Django settings below, do not touch!
 APPEND_SLASH = False
 TEMPLATE_DEBUG = False
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            join(dirname( abspath(__file__) ), 'templates')
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                # Insert your TEMPLATE_CONTEXT_PROCESSORS here or use this
+                # list if you haven't customized them:
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
     },
-}
+]
 
 # Language code for this installation. All choices can be found here:
 # http://www.w3.org/TR/REC-html40/struct/dirlang.html#langcodes
 # http://blogs.law.harvard.edu/tech/stories/storyReader$15
 LANGUAGE_CODE = 'en-us'
-
-SITE_ID = 1
 
 # Absolute path to the directory that holds media.
 MEDIA_ROOT = ''
@@ -47,18 +56,8 @@ MEDIA_ROOT = ''
 # Example: "http://media.lawrence.com"
 MEDIA_URL = ''
 
-# URL prefix for admin media -- CSS, JavaScript and images. Make sure to use a
-# trailing slash.
-# Examples: "http://foo.com/media/", "/media/".
-ADMIN_MEDIA_PREFIX = '/media/'
-
-# List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-  'django.template.loaders.filesystem.Loader',
-  'django.template.loaders.app_directories.Loader',
-)
-
 MIDDLEWARE_CLASSES = (
+  'graphite.middleware.LogExceptionsMiddleware',
   'django.middleware.common.CommonMiddleware',
   'django.middleware.gzip.GZipMiddleware',
   'django.contrib.sessions.middleware.SessionMiddleware',
@@ -71,7 +70,6 @@ ROOT_URLCONF = 'graphite.urls'
 INSTALLED_APPS = (
   'graphite.metrics',
   'graphite.render',
-  'graphite.cli',
   'graphite.browser',
   'graphite.composer',
   'graphite.account',
@@ -83,7 +81,7 @@ INSTALLED_APPS = (
   'django.contrib.sessions',
   'django.contrib.admin',
   'django.contrib.contenttypes',
-  'django.contrib.staticfiles', 
+  'django.contrib.staticfiles',
   'tagging',
 )
 
@@ -91,6 +89,6 @@ AUTHENTICATION_BACKENDS = ['django.contrib.auth.backends.ModelBackend']
 
 GRAPHITE_WEB_APP_SETTINGS_LOADED = True
 
-STATIC_URL = '/content/'
+STATIC_URL = '/static/'
 
-STATIC_ROOT='/opt/graphite/webapp/content/' 
+STATIC_ROOT = '/opt/graphite/static/'

--- a/conf/usr/local/bin/django_admin_init.exp
+++ b/conf/usr/local/bin/django_admin_init.exp
@@ -1,7 +1,7 @@
 #!/usr/bin/env expect
 
 set timeout -1
-spawn python /opt/graphite/webapp/graphite/manage.py syncdb
+spawn /usr/local/bin/manage.sh
 
 expect "Would you like to create one now" {
   send "yes\r"

--- a/conf/usr/local/bin/manage.sh
+++ b/conf/usr/local/bin/manage.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+PYTHONPATH=/opt/graphite/webapp django-admin.py syncdb --settings=graphite.settings
+PYTHONPATH=/opt/graphite/webapp django-admin.py update_users --settings=graphite.settings

--- a/conf/usr/local/bin/manage.sh
+++ b/conf/usr/local/bin/manage.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 PYTHONPATH=/opt/graphite/webapp django-admin.py syncdb --settings=graphite.settings
-PYTHONPATH=/opt/graphite/webapp django-admin.py update_users --settings=graphite.settings
+# PYTHONPATH=/opt/graphite/webapp django-admin.py update_users --settings=graphite.settings


### PR DESCRIPTION
Hi guys, 
I just wanted to submit some changes I made to the Dockerfile.

For my deployment, I use carbon-relay for availabity purposes. I added this line to the "daemon" section of Dockerfile:

`ADD conf/etc/service/carbon-relay/run /etc/service/carbon-relay/run`

And created the proper run file in `conf/etc/service/carbon-relay/run` with this content:

````
#!/bin/bash

rm -f /opt/graphite/storage/carbon-relay-a.pid
exec /usr/bin/python /opt/graphite/bin/carbon-relay.py start --debug 2>&1 >> /var/log/carbon-relay.log
````

Also, I exposed the relay ports both for UDP and TCP modifyng the "EXPOSED" line:
`EXPOSE 80 2003-2004 2003/udp 2013-2014 2013/udp 2023-2024 8125/udp 8126`

Thanks for this container, it really saved me a lot of time and effort :+1: 

Regards,