### PR TITLE
Support statsd TCP interface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ WORKDIR /usr/local/src/carbon
 RUN python ./setup.py install
 
 # install statsd
-RUN git clone -b v0.7.2 https://github.com/etsy/statsd.git /opt/statsd
+RUN git clone -b v0.8.0 https://github.com/etsy/statsd.git /opt/statsd
 
 # config graphite
 ADD conf/opt/graphite/conf/*.conf /opt/graphite/conf/

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ ADD conf/opt/graphite/webapp/graphite/app_settings.py /opt/graphite/webapp/graph
 RUN python /opt/graphite/webapp/graphite/manage.py collectstatic --noinput
 
 # config statsd
-ADD conf/opt/statsd/config.js /opt/statsd/config.js
+ADD conf/opt/statsd/config_*.js /opt/statsd/
 
 # config nginx
 RUN rm /etc/nginx/sites-enabled/default
@@ -86,8 +86,10 @@ RUN apt-get clean\
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # defaults
-EXPOSE 80 2003-2004 2023-2024 8125/udp 8126
+EXPOSE 80 2003-2004 2023-2024 8125 8125/udp 8126
 VOLUME ["/opt/graphite/conf", "/opt/graphite/storage", "/etc/nginx", "/opt/statsd", "/etc/logrotate.d", "/var/log"]
 WORKDIR /
 ENV HOME /root
+ENV STATSD_INTERFACE udp
+
 CMD ["/sbin/my_init"]

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Host | Container | Service
 8125 |      8125 | [statsd](https://github.com/etsy/statsd/blob/master/docs/server.md)
 8126 |      8126 | [statsd admin](https://github.com/etsy/statsd/blob/v0.7.2/docs/admin_interface.md)
 
+By default, statsd listens on the UDP port 8125. If you want it to listen on the TCP port 8125 instead, you can set the environment variable `STATSD_INTERFACE` to `tcp` when running the container.
 
 ### Mounted Volumes
 

--- a/conf/etc/service/statsd/run
+++ b/conf/etc/service/statsd/run
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-exec /usr/bin/nodejs /opt/statsd/stats.js /opt/statsd/config.js >> /var/log/statsd.log 2>&1
+exec /usr/bin/nodejs /opt/statsd/stats.js /opt/statsd/config_$STATSD_INTERFACE.js >> /var/log/statsd.log 2>&1
 

--- a/conf/opt/statsd/config.js
+++ b/conf/opt/statsd/config.js
@@ -1,6 +1,0 @@
-{
-  "graphiteHost": "127.0.0.1",
-  "graphitePort": 2003,
-  "port": 8125,
-  "flushInterval": 10000
-}

--- a/conf/opt/statsd/config_tcp.js
+++ b/conf/opt/statsd/config_tcp.js
@@ -1,0 +1,9 @@
+{
+  "graphiteHost": "127.0.0.1",
+  "graphitePort": 2003,
+  "port": 8125,
+  "flushInterval": 10000,
+  "servers": [
+    { server: "./servers/tcp", address: "0.0.0.0", port: 8125 }
+  ]
+}

--- a/conf/opt/statsd/config_udp.js
+++ b/conf/opt/statsd/config_udp.js
@@ -1,0 +1,10 @@
+{
+    "graphiteHost": "127.0.0.1",
+    "graphitePort": 2003,
+    "port": 8125,
+    "flushInterval": 10000,
+    "servers": [
+      { server: "./servers/udp", address: "0.0.0.0", port: 8125 }
+    ]
+  }
+  


### PR DESCRIPTION
This PR introduces support for the statsd TCP interface.

- 998e115 updates the statsd version to  v0.8.0, needed to have TCP support
- bf8f12a adds support for an environment variable that can be used to choose if statsd should listen on TCP or UDP. 

Example: 

```
docker run -d\
 --name graphite\
 --restart=always\
 -e STATSD_INTERFACE=tcp
 -p 80:80\
 -p 2003-2004:2003-2004\
 -p 2023-2024:2023-2024\
 -p 8125:8125/udp\
 -p 8126:8126\
 imagename
```