### PR TITLE
Url encoding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ ADD conf/opt/statsd/config_*.js /opt/statsd/
 RUN rm /etc/nginx/sites-enabled/default
 ADD conf/etc/nginx/nginx.conf /etc/nginx/nginx.conf
 ADD conf/etc/nginx/sites-enabled/graphite-statsd.conf /etc/nginx/sites-enabled/graphite-statsd.conf
+ADD conf/etc/nginx/fastcgi_params /etc/nginx/sites-enabled/graphite-statsd.conf
 
 # init django admin
 ADD conf/usr/local/bin/django_admin_init.exp /usr/local/bin/django_admin_init.exp

--- a/conf/etc/nginx/fastcgi_params
+++ b/conf/etc/nginx/fastcgi_params
@@ -1,0 +1,23 @@
+fastcgi_param   QUERY_STRING            $query_string;
+fastcgi_param   REQUEST_METHOD          $request_method;
+fastcgi_param   CONTENT_TYPE            $content_type;
+fastcgi_param   CONTENT_LENGTH          $content_length;
+
+fastcgi_param   SCRIPT_FILENAME         $request_filename;
+fastcgi_param   SCRIPT_NAME             $fastcgi_script_name;
+fastcgi_param   REQUEST_URI             $uri;
+fastcgi_param   DOCUMENT_URI            $document_uri;
+fastcgi_param   DOCUMENT_ROOT           $document_root;
+fastcgi_param   SERVER_PROTOCOL         $server_protocol;
+
+fastcgi_param   GATEWAY_INTERFACE       CGI/1.1;
+fastcgi_param   SERVER_SOFTWARE         nginx/$nginx_version;
+
+fastcgi_param   REMOTE_ADDR             $remote_addr;
+fastcgi_param   REMOTE_PORT             $remote_port;
+fastcgi_param   SERVER_ADDR             $server_addr;
+fastcgi_param   SERVER_PORT             $server_port;
+fastcgi_param   SERVER_NAME             $server_name;
+
+fastcgi_param   HTTPS                   $https if_not_empty;
+


### PR DESCRIPTION
Nginx was handing over the the URL with spaces as '%20'

The FastCGI params have been updated with $uri instead of $request_uri to give the app the correct and expected nginx var.